### PR TITLE
Fix escapes decoding in toJSON

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -35,7 +35,7 @@ export abstract class JsonNode implements IJsonNode {
   public readonly type: JsonNodeTypes = JsonNodeTypes.ERROR;
 
   public accept(visitor: Visitor): void {
-    visitor.visit(this as any);
+    visitor.visit(this as unknown as JsonNodeType);
   }
 }
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -82,7 +82,7 @@ export class JsonValue extends JsonNode implements IJsonValue {
 export class JsonKey extends JsonNode implements IJsonValue {
   public readonly type: JsonNodeTypes.KEY = JsonNodeTypes.KEY;
 
-  constructor(public value: string = null, public decoded: string = null, ) {
+  constructor(public value: string = null, public decoded: string = null) {
     super();
   }
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -82,7 +82,7 @@ export class JsonValue extends JsonNode implements IJsonValue {
 export class JsonKey extends JsonNode implements IJsonValue {
   public readonly type: JsonNodeTypes.KEY = JsonNodeTypes.KEY;
 
-  constructor(public value: string = null) {
+  constructor(public value: string = null, public decoded: string = null, ) {
     super();
   }
 }
@@ -98,7 +98,7 @@ export class JsonComment extends JsonNode implements IJsonValue {
 export class JsonString extends JsonNode implements IJsonValue {
   public readonly type: JsonNodeTypes.STRING = JsonNodeTypes.STRING;
 
-  constructor(public value: string = null) {
+  constructor(public value: string = null, public decoded: string = null) {
     super();
   }
 }
@@ -163,10 +163,10 @@ export type JsonNodeType =
 // Utility methods to construct the objects
 //
 export class NodeFactory {
-  static fromType<T extends JsonNode>(objectType: JsonNodeTypes, _value = null): T {
+  static fromType<T extends JsonNode>(objectType: JsonNodeTypes, _value = null, _decoded = null): T {
     const clazz = nodeTypeObjectMapping[objectType];
     if (clazz === null) throw new Error(`AST node of type ${objectType} cannot be found`);
-    return _value !== null ? new clazz(_value) : new clazz();
+    return new clazz(_value, _decoded);
   }
 }
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -193,9 +193,10 @@ function recursiveNodeConversion(rootNode: JsonNodeType): any {
       return result;
     }
     case JsonNodeTypes.VALUE:
+      return rootNode.value;
     case JsonNodeTypes.STRING:
     case JsonNodeTypes.KEY:
-      return rootNode.value;
+      return rootNode.decoded ?? rootNode.value;
     case JsonNodeTypes.NUMBER: {
       if (typeof rootNode.value !== "number") return parseFloat((rootNode as any).value);
       return rootNode.value;

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -88,7 +88,7 @@ export class JsonKey extends JsonNode implements IJsonValue {
 }
 
 export class JsonComment extends JsonNode implements IJsonValue {
-  public readonly type: JsonNodeTypes.KEY = JsonNodeTypes.KEY;
+  public readonly type: JsonNodeTypes.COMMENT = JsonNodeTypes.COMMENT;
 
   constructor(public value: string = null) {
     super();

--- a/src/junker.ts
+++ b/src/junker.ts
@@ -1,6 +1,5 @@
 // import util from 'util';
-import { JsonTokenTypes } from "./tokenize.js";
-import { JsonToken, ParseSettings } from "./types.js";
+import { JsonTokenTypes, JsonToken, ParseSettings } from "./types.js";
 
 function findLastTokenIndexIn(tokenList, JsonTokenTypes): number {
   let rindex = tokenList.length - 1;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -75,7 +75,11 @@ function parseValue(
   }
   if (nodeType) {
     index++;
-    const value = NodeFactory.fromType<JsonValue>(nodeType, token.value);
+    const value = (
+      nodeType === JsonNodeTypes.STRING
+        ? NodeFactory.fromType<JsonValue>(nodeType, token.value, token.decoded)
+        : NodeFactory.fromType<JsonValue>(nodeType, token.value)
+    );
     if (settings.verbose) {
       value.position = token.position;
     }
@@ -140,7 +144,7 @@ function parseObject(
       case objectStates.OPEN_OBJECT: {
         if (token.type === JsonTokenTypes.STRING) {
           property = NodeFactory.fromType<JsonProperty>(JsonNodeTypes.PROPERTY);
-          property.key = NodeFactory.fromType<JsonKey>(JsonNodeTypes.KEY, token.value);
+          property.key = NodeFactory.fromType<JsonKey>(JsonNodeTypes.KEY, token.value, token.decoded);
 
           if (settings.verbose) {
             property.key.position = token.position;
@@ -239,7 +243,7 @@ function parseObject(
       case objectStates.COMMA: {
         if (token.type === JsonTokenTypes.STRING) {
           property = NodeFactory.fromType<JsonProperty>(JsonNodeTypes.PROPERTY);
-          property.key = NodeFactory.fromType<JsonKey>(JsonNodeTypes.KEY, token.value);
+          property.key = NodeFactory.fromType<JsonKey>(JsonNodeTypes.KEY, token.value, token.decoded);
 
           if (settings.verbose) {
             property.key.position = token.position;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -15,8 +15,8 @@ import { error } from "./error.js";
 import { junker } from "./junker.js";
 import { unexpectedEnd, unexpectedToken } from "./parseErrorTypes.js";
 import { JsonPosition } from "./position.js";
-import { JsonTokenTypes, tokenize } from "./tokenize.js";
-import { JsonToken, ParseResult, ParseSettings } from "./types.js";
+import { tokenize } from "./tokenize.js";
+import { JsonTokenTypes, JsonToken, ParseResult, ParseSettings } from "./types.js";
 
 // import util from 'util';
 
@@ -49,33 +49,33 @@ function parseValue(
 ): ParseResult<IJsonNode> {
   // value: object | array | STRING | NUMBER | TRUE | FALSE | NULL | COMMENT
   const token = tokenList[index];
-  let tokenType: JsonNodeTypes;
+  let nodeType: JsonNodeTypes;
 
   switch (token.type) {
     case JsonTokenTypes.STRING:
-      tokenType = JsonNodeTypes.STRING;
+      nodeType = JsonNodeTypes.STRING;
       break;
     case JsonTokenTypes.NUMBER:
-      tokenType = JsonNodeTypes.NUMBER;
+      nodeType = JsonNodeTypes.NUMBER;
       break;
     case JsonTokenTypes.TRUE:
-      tokenType = JsonNodeTypes.TRUE;
+      nodeType = JsonNodeTypes.TRUE;
       break;
     case JsonTokenTypes.FALSE:
-      tokenType = JsonNodeTypes.FALSE;
+      nodeType = JsonNodeTypes.FALSE;
       break;
     case JsonTokenTypes.NULL:
-      tokenType = JsonNodeTypes.NULL;
+      nodeType = JsonNodeTypes.NULL;
       break;
     case JsonTokenTypes.COMMENT:
-      tokenType = JsonNodeTypes.COMMENT;
+      nodeType = JsonNodeTypes.COMMENT;
       break;
     default:
       break;
   }
-  if (tokenType) {
+  if (nodeType) {
     index++;
-    const value = NodeFactory.fromType<JsonValue>(tokenType, token.value);
+    const value = NodeFactory.fromType<JsonValue>(nodeType, token.value);
     if (settings.verbose) {
       value.position = token.position;
     }
@@ -106,12 +106,11 @@ function parseObject(
   index: number,
   settings: ParseSettings,
 ): ParseResult<JsonObject> {
-  let startToken;
-  let property;
   const object = NodeFactory.fromType<JsonObject>(JsonNodeTypes.OBJECT);
-
+  let startToken: JsonToken;
+  let token: JsonToken;
+  let property: JsonProperty;
   let state = objectStates._START_;
-  let token;
 
   while (index < tokenList.length) {
     token = tokenList[index];
@@ -198,7 +197,7 @@ function parseObject(
       case objectStates.COLON: {
         const value = parseValue(source, tokenList, index, settings);
         index = value.index;
-        property.value = value.value;
+        property.value = value.value as JsonValue;
 
         object.properties.push(property);
         state = objectStates.VALUE;
@@ -278,10 +277,10 @@ function parseArray(
   index: number,
   settings: ParseSettings,
 ): ParseResult<JsonArray> {
-  let startToken;
   const array = NodeFactory.fromType<JsonArray>(JsonNodeTypes.ARRAY);
+  let startToken: JsonToken;
+  let token: JsonToken;
   let state = arrayStates._START_;
-  let token;
   while (index < tokenList.length) {
     token = tokenList[index];
     if (token.type === JsonTokenTypes.COMMENT) {

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,23 +1,7 @@
 import { error } from "./error.js";
 import { JsonPosition } from "./position.js";
 import { cannotTokenizeSymbol } from "./tokenizeErrorTypes.js";
-import { JsonToken, ParseSettings } from "./types.js";
-
-export enum JsonTokenTypes {
-  COMMENT = "COMMENT", // // ... \n\r? or /* ... */
-  LEFT_BRACE = "LEFT_BRACE", // {
-  RIGHT_BRACE = "RIGHT_BRACE", // }
-  LEFT_BRACKET = "LEFT_BRACKET", // [
-  RIGHT_BRACKET = "RIGHT_BRACKET", // ]
-  COLON = "COLON", //  :
-  COMMA = "COMMA", // ,
-  STRING = "STRING", //
-  NUMBER = "NUMBER", //
-  TRUE = "TRUE", // true
-  FALSE = "FALSE", // false
-  NULL = "NULL", // null
-  IDENTIFIER = "IDENTIFIER", // identifiers
-}
+import { JsonToken, JsonTokenTypes, ParseSettings } from "./types.js";
 
 interface ParseJsonToken {
   type: JsonTokenTypes;
@@ -310,8 +294,8 @@ function parseString(source: string, index: number, line: number, column: number
           return {
             type: JsonTokenTypes.STRING,
             value: buffer,
-            line: line,
-            index: index,
+            line,
+            index,
             column: column + index - startIndex,
           };
         } else {
@@ -487,7 +471,7 @@ export function tokenize(source: string, settings?: ParseSettings): JsonToken[] 
       parseString(source, index, line, column) ||
       parseNumber(source, index, line, column);
     if (matched) {
-      const token = { type: matched.type, value: matched.value } as JsonToken;
+      const token: JsonToken = { type: matched.type, value: matched.value };
 
       if (settings.verbose) {
         token.position = new JsonPosition(line, column, index, matched.line, matched.column, matched.index);

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -62,23 +62,23 @@ const numberStates = {
 
 // HELPERS
 
-function isDigit1to9(char): boolean {
+function isDigit1to9(char: string): boolean {
   return char >= "1" && char <= "9";
 }
 
-function isDigit(char): boolean {
+function isDigit(char: string): boolean {
   return char >= "0" && char <= "9";
 }
 
-function isLetter(char): boolean {
+function isLetter(char: string): boolean {
   return (char >= "a" && char <= "z") || (char >= "A" && char <= "Z");
 }
 
-function isHex(char): boolean {
+function isHex(char: string): boolean {
   return isDigit(char) || (char >= "a" && char <= "f") || (char >= "A" && char <= "F");
 }
 
-function isExp(char): boolean {
+function isExp(char: string): boolean {
   return char === "e" || char === "E";
 }
 
@@ -222,7 +222,7 @@ function parseChar(source: string, index: number, line: number, column: number):
 }
 
 function parseKeyword(source: string, index: number, line: number, column: number): ParseJsonToken | null {
-  const matched = Object.keys(keywordsTokens).find((name) => name === source.substr(index, name.length));
+  const matched = Object.keys(keywordsTokens).find((name) => name === source.slice(index, index + name.length));
 
   if (matched) {
     return {

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -34,13 +34,11 @@ const stringStates = {
 };
 
 const symbolSubstitutes = {
-  0: '\0', // Quotation mask
   b: '\b', // Backspace
   f: '\f', // Form feed
   n: '\n', // New line
   r: '\r', // Carriage return
   t: '\t', // Horizontal tab
-  v: '\v', // Vertical tab
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences
@@ -48,14 +46,12 @@ const escapes = {
   '"': 0, // Quotation mask
   "\\": 1, // Reverse solidus
   "/": 2, // Solidus
-  0: 3, // Null character
-  b: 4, // Backspace
-  f: 5, // Form feed
-  n: 6, // New line
-  r: 7, // Carriage return
-  t: 8, // Horizontal tab
-  v: 9, // Vertical tab
-  u: 10, // 4 hexadecimal digits
+  b: 3, // Backspace
+  f: 4, // Form feed
+  n: 5, // New line
+  r: 6, // Carriage return
+  t: 7, // Horizontal tab
+  u: 8, // 4 hexadecimal digits
 };
 
 // Support regex

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -34,23 +34,28 @@ const stringStates = {
 };
 
 const symbolSubstitutes = {
+  0: '\0', // Quotation mask
   b: '\b', // Backspace
   f: '\f', // Form feed
   n: '\n', // New line
   r: '\r', // Carriage return
   t: '\t', // Horizontal tab
+  v: '\v', // Vertical tab
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences
 const escapes = {
   '"': 0, // Quotation mask
   "\\": 1, // Reverse solidus
   "/": 2, // Solidus
-  b: 3, // Backspace
-  f: 4, // Form feed
-  n: 5, // New line
-  r: 6, // Carriage return
-  t: 7, // Horizontal tab
-  u: 8, // 4 hexadecimal digits
+  0: 3, // Null character
+  b: 4, // Backspace
+  f: 5, // Form feed
+  n: 6, // New line
+  r: 7, // Carriage return
+  t: 8, // Horizontal tab
+  v: 9, // Vertical tab
+  u: 10, // 4 hexadecimal digits
 };
 
 // Support regex

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -6,7 +6,7 @@ import { JsonToken, JsonTokenTypes, ParseSettings } from "./types.js";
 interface ParseJsonToken {
   type: JsonTokenTypes;
   value: string;
-  decoded?: string;
+  decoded?: string | null;
   line: number;
   index: number;
   column: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,22 @@
 import { IJsonNode } from "./ast.js";
 import { JsonPosition } from "./position.js";
+
+export enum JsonTokenTypes {
+  COMMENT = "COMMENT", // // ... \n\r? or /* ... */
+  LEFT_BRACE = "LEFT_BRACE", // {
+  RIGHT_BRACE = "RIGHT_BRACE", // }
+  LEFT_BRACKET = "LEFT_BRACKET", // [
+  RIGHT_BRACKET = "RIGHT_BRACKET", // ]
+  COLON = "COLON", //  :
+  COMMA = "COMMA", // ,
+  STRING = "STRING", //
+  NUMBER = "NUMBER", //
+  TRUE = "TRUE", // true
+  FALSE = "FALSE", // false
+  NULL = "NULL", // null
+  IDENTIFIER = "IDENTIFIER", // identifiers
+}
+
 export interface ParseResult<T extends IJsonNode> {
   value: T;
   index: number;
@@ -11,7 +28,7 @@ export interface ParseSettings {
 }
 
 export interface JsonToken {
-  type: any;
-  value: any;
+  type: JsonTokenTypes;
+  value: string;
   position?: JsonPosition;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,5 +30,6 @@ export interface ParseSettings {
 export interface JsonToken {
   type: JsonTokenTypes;
   value: string;
+  decoded?: string;
   position?: JsonPosition;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,6 @@ export interface ParseSettings {
 export interface JsonToken {
   type: JsonTokenTypes;
   value: string;
-  decoded?: string;
+  decoded?: string | null;
   position?: JsonPosition;
 }

--- a/test/cases/string-escaping.ts
+++ b/test/cases/string-escaping.ts
@@ -1,20 +1,20 @@
-import { createDocument, createObject, createObjectKey, createObjectProperty, createString } from "../types";
+import { createDocument, createObject, createEscapedObjectKey, createObjectProperty, createEscapedString } from "../types";
 
 const object = createObject;
-const key = createObjectKey;
+const key = createEscapedObjectKey;
 const prop = createObjectProperty;
-const string = createString;
+const string = createEscapedString;
 const doc = createDocument;
 
 const ast = object([
-  prop(key('quota\\"tion'), string("reverse\\\\solidus")),
-  prop(key("soli\\/dus"), string("back\\bspace")),
-  prop(key("form\\ffeed"), string("new\\nline")),
-  prop(key("re\\rturn"), string("tab\\tsymbol")),
-  prop(key("hex\\u0001digit"), string("")),
-  prop(key('\\"\\"\\"\\"'), string("\\\\\\\\\\\\")),
-  prop(key("\\/"), string("\\b")),
-  prop(key('\\"\\/'), string('\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001')),
+  prop(key('quota\\"tion', 'quota"tion'), string("reverse\\\\solidus", "reverse\\solidus")),
+  prop(key("soli\\/dus", "soli/dus"), string("back\\bspace", "back\bspace")),
+  prop(key("form\\ffeed", "form\ffeed"), string("new\\nline", "new\nline")),
+  prop(key("re\\rturn", "re\rturn"), string("tab\\tsymbol", "tab\tsymbol")),
+  prop(key("hex\\u0001digit", "hex\u0001digit"), string("", null)),
+  prop(key('\\"\\"\\"\\"', '\"\"\"\"'), string("\\\\\\\\\\\\", "\\\\\\")),
+  prop(key("\\/", "\/"), string("\\b", "\b")),
+  prop(key('\\"\\/', '\"\/'), string('\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001', '\"\\\/\b\f\n\r\t\u0001')),
 ]);
 
 export = {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -175,4 +175,21 @@ describe("Object conversion to native JSON", function () {
 
     expect(JSON_TESTCASE).toEqual(toJSON(documentNode));
   });
+
+  it("should convert properly escaped keys and values", function () {
+    const JSON_TESTCASE = {
+      "hex\u0001digit\"\/": "\"\\\/\b\f\n\r\t\u0001",
+      a: {
+        "hex\u0001digit\"\/": "\"\\\/\b\f\n\r\t\u0001",
+        b: [
+          "hex\u0001digit\"\/", "\"\\\/\b\f\n\r\t\u0001"
+        ],
+      },
+    };
+
+    const NORMAL_JSON_BUFFER = JSON.stringify(JSON_TESTCASE);
+    const documentNode = parse(NORMAL_JSON_BUFFER);
+
+    expect(JSON_TESTCASE).toEqual(toJSON(documentNode));
+  });
 });

--- a/test/types.ts
+++ b/test/types.ts
@@ -48,7 +48,7 @@ export function createObjectKey(value, position?: JsonPosition): JsonKey {
 }
 
 export function createEscapedObjectKey(value: string, decoded: string, position?: JsonPosition): JsonKey {
-  const result = new JsonKey(value);
+  const result = new JsonKey(value, decoded);
 
   if (position) {
     result.position = position;
@@ -114,7 +114,7 @@ export function createString(value, position?: JsonPosition): JsonString {
 }
 
 export function createEscapedString(value: string, decoded: string, position?: JsonPosition): JsonString {
-  const result = new JsonString(value);
+  const result = new JsonString(value, decoded);
 
   if (position) {
     result.position = position;

--- a/test/types.ts
+++ b/test/types.ts
@@ -47,6 +47,16 @@ export function createObjectKey(value, position?: JsonPosition): JsonKey {
   return result;
 }
 
+export function createEscapedObjectKey(value: string, decoded: string, position?: JsonPosition): JsonKey {
+  const result = new JsonKey(value);
+
+  if (position) {
+    result.position = position;
+  }
+
+  return result;
+}
+
 export function createObjectProperty(key, value): JsonProperty {
   const result = new JsonProperty();
   result.key = key;
@@ -94,6 +104,16 @@ export function createComment(value, position?: JsonPosition): JsonComment {
 }
 
 export function createString(value, position?: JsonPosition): JsonString {
+  const result = new JsonString(value);
+
+  if (position) {
+    result.position = position;
+  }
+
+  return result;
+}
+
+export function createEscapedString(value: string, decoded: string, position?: JsonPosition): JsonString {
   const result = new JsonString(value);
 
   if (position) {

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "esnext",
+    "target": "ES6",
     "outDir": "dist/esm"
   },
   "exclude": [


### PR DESCRIPTION
Closes #1180 

May be worth noting: i've change the build target for the esm build from `es5` to `es6`, as environments, that support ESM by default either also support `es6` (nodejs, modern-ish browsers with ESM support etc.), or would be consuming the library through an additional transpilation step (namely, Internet Explorer 11). Feel free to revert the change, it is not critical to the PR, just optimizes the esm build by _a lot_ 